### PR TITLE
Explanations in le: Update to the explanations for LE (rule highlighting)

### DIFF
--- a/kb/0_citizenship.pl
+++ b/kb/0_citizenship.pl
@@ -1,4 +1,4 @@
-:- module('citizenship+https://www.legislation.gov.uk/ukpga/1981/61/body/',[]).
+:- module('citizenship+https://www.legislation.gov.uk/ukpga/1981/61/section/1',[]).
 
 en("the target language is: prolog.
 
@@ -18,7 +18,7 @@ a person acquires British citizenship on a date
 if the person is born in the UK on the date
 and the date is after commencement
 and an other person is the mother of the person
-    or an other person is the father of the person
+    or the other person is the father of the person
 and the other person is a British citizen on the date
     or the other person is settled in the UK on the date.
 

--- a/kb/0_proof-trees.pl
+++ b/kb/0_proof-trees.pl
@@ -1,0 +1,39 @@
+% Logical English document
+
+% an example of a prolog module name. Please adjust as convenient
+:- module('proof+http://tests.com',[]).
+
+en("the target language is: prolog. % other languages available soon
+
+the templates are:
+   predicate one *a number*,
+   predicate two *a number*,
+   predicate three *a number*,
+   predicate four *a number*,
+   predicate five *a number*, 
+   solution.
+ 
+the knowledge base proof includes:
+solution
+    if predicate one a first choice
+    and predicate two a second choice
+    and predicate three a third choice
+     	or predicate five the third choice
+    and predicate four a fourth choice
+    	or predicate five the fourth choice.
+
+scenario one is:
+    predicate one one.
+    predicate two two.
+    predicate five three.
+    predicate four four. 
+
+query one is:
+	solution.
+
+").
+/** <examples>
+?- answer("query one with scenario one").
+?- answer("query three with scenario one").
+?- answer("query two with scenario one")
+*/

--- a/kb/LogicalEnglish.swinb
+++ b/kb/LogicalEnglish.swinb
@@ -59,7 +59,7 @@ of one condition per line with a level of indentation that corresponds to each o
 </div>
 
 <div class="nb-cell program" name="citizenship">
-:- module('010+http://tests.com',[]).
+:- module('citizenship+https://www.legislation.gov.uk/ukpga/1981/61/section/1',[]).
 
 en("the target language is: prolog.
 
@@ -79,7 +79,7 @@ a person acquires British citizenship on a date
 if the person is born in the UK on the date
 and the date is after commencement
 and an other person is the mother of the person
-    or an other person is the father of the person
+    or the other person is the father of the person
 and the other person is a British citizen on the date
     or the other person is settled in the UK on the date.
 

--- a/le_input.pl
+++ b/le_input.pl
@@ -1765,34 +1765,6 @@ interrupted(T1, Fluent, T2) :- %trace,
     %(nonvar(T2) -> rbefore(T, T2) ; true ), !.  
     %(T2=(after(T1)-_)->T2=(after(T1)-before(T)); rbefore(T,T2)). 
 
-% experimental; BUG: apparently LE-originated clauses are not being asserted as in TaxLog; 
-% TODO: cleanup, refactor with answer(...)
-explainedAnswer(English,Unknowns,Explanation,Result) :- %trace, 
-    (parsed -> true; fail), !, 
-    pengine_self(SwishModule), 
-    (translate_command(SwishModule, English, GoalName, Goal, Scenario) -> true 
-    ; ( print_message(error, "Don't understand this question: ~w "-[English]), !, fail ) ), % later -->, Kbs),
-    copy_term(Goal, CopyOfGoal),  
-    get_answer_from_goal(CopyOfGoal, RawGoal), name_as_atom(RawGoal, EnglishQuestion), 
-    print_message(informational, "Query ~w with ~w: ~w"-[GoalName, Scenario, EnglishQuestion]),
-    print_message(informational, "Scenario: ~w"-[Scenario]),
-    % assert facts in scenario
-    (Scenario==noscenario -> true ; %Facts = [] ; 
-        (SwishModule:example(Scenario, [scenario(_Facts, _)]) -> 
-            true;  print_message(error, "Scenario: ~w does not exist"-[Scenario]))), !,  
-    %print_message(informational, "Facts: ~w"-[Facts]), 
-    extract_goal_command(Goal, SwishModule, InnerGoal, Command), 
-    print_message(informational, "Command: ~w"-[Command]),
-    query_with_facts(at(InnerGoal,SwishModule),Scenario,Unknowns,Explanation,Result),
-    print_message(informational,"Result:~w, Explanation: ~w"-[Result,Explanation]),
-    print_message(informational,"Unknowns: ~w"-[Unknowns]),
-    % setup_call_catcher_cleanup(assert_facts(SwishModule, Facts), 
-    %         catch((Command), Error, ( print_message(error, Error), fail ) ), 
-    %         _Result, 
-    %         retract_facts(SwishModule, Facts)), % probably not necessary, the SWISH module is transient
-    get_answer_from_goal(Goal, RawAnswer), name_as_atom(RawAnswer, EnglishAnswer),  
-    print_message(informational, "Answer: ~w"-[EnglishAnswer]).
-
 /* ----------------------------------------------------------------- CLI English */
 % answer/1
 % answer(+Query or Query Expression)
@@ -2097,7 +2069,6 @@ user:answer( EnText) :- answer( EnText).
 user:answer( EnText, Scenario) :- answer( EnText, Scenario).
 user:answer( EnText, Scenario, Result) :- answer( EnText, Scenario, Result).
 user:answer( EnText, Scenario, E, Result) :- answer( EnText, Scenario, E, Result).
-user:explainedAnswer(Query,Unknowns,Explanation,Result) :- explainedAnswer(Query,Unknowns,Explanation,Result).
 
 user:(show Something) :- 
     show(Something). 

--- a/le_input.pl
+++ b/le_input.pl
@@ -90,7 +90,7 @@ query three is:
     op(800,fx,user:show), % to support querying
     op(850,xfx,user:of), % to support querying
     dictionary/3, meta_dictionary/3,
-    get_answer_from_goal/2, name_as_atom/2
+    get_answer_from_goal/2, name_as_atom/2, parsed/0
     ]).
 :- use_module('./tokenize/prolog/tokenize.pl').
 :- use_module(library(pengines)).
@@ -509,8 +509,8 @@ conditions(Ind0, Map1, MapN, Conds) -->
 more_conds(Ind0, Ind1, Ind3, Map1, MapN, Cond, RestMapped) --> 
     newline, spaces(Ind2), {Ind0 =< Ind2}, % if the new indentation is deeper, it goes on as before. 
     operator(Op), condition(Cond2, Ind2, Map1, Map2),
-    {add_cond(Op, Ind1, Ind2, Cond, Cond2, Conditions)},  
-    {print_message(informational, "~w"-[Conditions])}, !,
+    {add_cond(Op, Ind1, Ind2, Cond, Cond2, Conditions)},  !, 
+    %{print_message(informational, "~w"-[Conditions])}, !,
     more_conds(Ind0, Ind2, Ind3, Map2, MapN, Conditions, RestMapped). 
 more_conds(_, Ind, Ind, Map, Map, Cond, Cond, Rest, Rest).  
  
@@ -1878,6 +1878,7 @@ answer(English, Arg, E, Result) :- %trace,
             retract_facts(SwishModule, Facts)). 
 
 % get_answer_from_goal/2
+% get_answer_from_goal(+Goals_after_being_queried, -Goals_translated_into_LEnglish_as_answers)
 get_answer_from_goal((G,R), WholeAnswer) :- 
     get_answer_from_goal(G, Answer), 
     get_answer_from_goal(R, RestAnswers), !, 
@@ -2053,11 +2054,11 @@ show(types) :-
     setof(Ty, is_type(Ty), Set), 
     forall(member(T, Set), print_message(informational, '~a'-[T])).
 
-unwrapBody(taxlogBody(Body, _, _, _, _), Body). 
+unwrapBody(targetBody(Body, _, _, _, _, _), Body). 
 %unwrapBody(Body, Body). 
 
 % hack to bring in the reasoner for explanations.  
-taxlogBody(G, false, _, '', []) :- %trace, 
+targetBody(G, false, _, '', [], _) :- %trace, 
     %nonvar(G),
     pengine_self(SwishModule), extract_goal_command(G, SwishModule, _InnerG, Command), % clean extract goals
     %print_message(informational, "Trying ~w"-[Command]), 
@@ -2102,7 +2103,7 @@ user:le_taxlog_translate( en(Text), Terms) :- le_taxlog_translate( en(Text), Ter
 
 user:op_stop(StopWords) :- op_stop(StopWords). 
 
-user:taxlogBody(G, B, X, S, L) :- taxlogBody(G, B, X, S, L). 
+user:targetBody(G, B, X, S, L, R) :- targetBody(G, B, X, S, L, R). 
 
 le_taxlog_translate( EnText, Terms) :- le_taxlog_translate( EnText, someFile, 1, Terms).
 

--- a/le_input.pl
+++ b/le_input.pl
@@ -2124,5 +2124,4 @@ sandbox:safe_primitive(le_input:show( _Something)).
 sandbox:safe_primitive(le_input:answer( _EnText, _Scenario)).
 sandbox:safe_primitive(le_input:answer( _EnText, _Scenario, _Result)).
 sandbox:safe_primitive(le_input:answer( _EnText, _Scenario, _Explanation, _Result)).
-sandbox:safe_primitive(le_input:explainedAnswer(_,_,_,_)).
 sandbox:safe_primitive(le_input:le_taxlog_translate( _EnText, _Terms)).

--- a/reasoner.pl
+++ b/reasoner.pl
@@ -548,25 +548,28 @@ simplify_explanation([],V,V,[]).
 % expand_explanation_refs(+ExpandedWhy,+ExtraFacts,-ExpandedRefLessWhy)
 % TODO: recover original variable names? seems to require either some hacking with clause_info or reparsing
 % transforms explanation: each nodetype(Literal,Module,ClauseRef,Children) --> nodetype(Literal,ClauseRef,Module,SourceString,OriginURL,Children)
-expand_explanation_refs([Node|Nodes],Facts, AllNodes) :-  
+expand_explanation_refs([Node|Nodes],Facts, [NewNode|NewNodes]) :-  
     Node=..[Type,X,Module,Ref,Children], 
     refToSourceAndOrigin(Ref,Source,Origin),
     %TODO: is the following test against facts necessary???:
     ((member(XX,Facts), variant(XX,X)) -> NewOrigin=userFact ; NewOrigin=Origin),
-    (translate_to_le(X, EnglishAnswer) -> 
-      %print_message(informational, "Explaining ~w as ~w"-[X, EnglishAnswer])
-      ( Output = EnglishAnswer,            
-        NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-        expand_explanation_refs(Children,Facts,NewChildren),
-        AllNodes = [NewNode|NewNodes]
+    (X\=[] -> 
+        (translate_to_le(X, EnglishAnswer) -> 
+            %print_message(informational, "Explaining ~w as ~w"-[X, EnglishAnswer])
+            ( Output = EnglishAnswer            
+            %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+            %expand_explanation_refs(Children,Facts,NewChildren),
+            %AllNodes = [NewNode|NewNodes]
+            )
+        ; %print_message(informational, "Can't translate ~w"-[X])
+            Output='it has not yet been proven'
         )
-    ; %print_message(informational, "Can't translate ~w"-[X])
-        %Output = false(X)
-        AllNodes = NewNodes
+    ;         %AllNodes = NewNodes
+        Output = 'it is a fact'
     ),
     %translate_to_le(X, Output),      
-    %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-    %expand_explanation_refs(Children,Facts,NewChildren),
+    NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+    expand_explanation_refs(Children,Facts,NewChildren),
     expand_explanation_refs(Nodes,Facts,NewNodes).
 expand_explanation_refs([],_,[]). 
 

--- a/reasoner.pl
+++ b/reasoner.pl
@@ -548,25 +548,27 @@ simplify_explanation([],V,V,[]).
 % expand_explanation_refs(+ExpandedWhy,+ExtraFacts,-ExpandedRefLessWhy)
 % TODO: recover original variable names? seems to require either some hacking with clause_info or reparsing
 % transforms explanation: each nodetype(Literal,Module,ClauseRef,Children) --> nodetype(Literal,ClauseRef,Module,SourceString,OriginURL,Children)
-expand_explanation_refs([Node|Nodes],Facts, AllNodes) :-  
+expand_explanation_refs([Node|Nodes],Facts, [NewNode|NewNodes]) :-  
     Node=..[Type,X,Module,Ref,Children], 
     refToSourceAndOrigin(Ref,Source,Origin),
     %TODO: is the following test against facts necessary???:
     ((member(XX,Facts), variant(XX,X)) -> NewOrigin=userFact ; NewOrigin=Origin),
     (translate_to_le(X, EnglishAnswer) -> 
       %print_message(informational, "Explaining ~w as ~w"-[X, EnglishAnswer])
-      ( Output = EnglishAnswer,            
-        NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-        expand_explanation_refs(Children,Facts,NewChildren),
-        AllNodes = [NewNode|NewNodes]
+      ( Output = EnglishAnswer            
+        %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+        %expand_explanation_refs(Children,Facts,NewChildren),
+        %AllNodes = [NewNode|NewNodes]
         )
     ; %print_message(informational, "Can't translate ~w"-[X])
-        %Output = false(X)
-        AllNodes = NewNodes
+        (X=[]-> Output = 'it is a fact' ; Output = 'it has not been disproven yet')           
+        %NewNode2=..[Type,false(X),Ref,Module,Source,NewOrigin,NewChildren],
+        %AllNodes = [NewNode2|NewNodes]
+        %AllNodes = NewNodes
     ),
     %translate_to_le(X, Output),      
-    %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-    %expand_explanation_refs(Children,Facts,NewChildren),
+    NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+    expand_explanation_refs(Children,Facts,NewChildren),
     expand_explanation_refs(Nodes,Facts,NewNodes).
 expand_explanation_refs([],_,[]). 
 

--- a/reasoner.pl
+++ b/reasoner.pl
@@ -548,27 +548,25 @@ simplify_explanation([],V,V,[]).
 % expand_explanation_refs(+ExpandedWhy,+ExtraFacts,-ExpandedRefLessWhy)
 % TODO: recover original variable names? seems to require either some hacking with clause_info or reparsing
 % transforms explanation: each nodetype(Literal,Module,ClauseRef,Children) --> nodetype(Literal,ClauseRef,Module,SourceString,OriginURL,Children)
-expand_explanation_refs([Node|Nodes],Facts, [NewNode|NewNodes]) :-  
+expand_explanation_refs([Node|Nodes],Facts, AllNodes) :-  
     Node=..[Type,X,Module,Ref,Children], 
     refToSourceAndOrigin(Ref,Source,Origin),
     %TODO: is the following test against facts necessary???:
     ((member(XX,Facts), variant(XX,X)) -> NewOrigin=userFact ; NewOrigin=Origin),
     (translate_to_le(X, EnglishAnswer) -> 
       %print_message(informational, "Explaining ~w as ~w"-[X, EnglishAnswer])
-      ( Output = EnglishAnswer            
-        %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-        %expand_explanation_refs(Children,Facts,NewChildren),
-        %AllNodes = [NewNode|NewNodes]
+      ( Output = EnglishAnswer,            
+        NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+        expand_explanation_refs(Children,Facts,NewChildren),
+        AllNodes = [NewNode|NewNodes]
         )
     ; %print_message(informational, "Can't translate ~w"-[X])
-        (X=[]-> Output = 'it is a fact' ; Output = 'it has not been disproven yet')           
-        %NewNode2=..[Type,false(X),Ref,Module,Source,NewOrigin,NewChildren],
-        %AllNodes = [NewNode2|NewNodes]
-        %AllNodes = NewNodes
+        %Output = false(X)
+        AllNodes = NewNodes
     ),
     %translate_to_le(X, Output),      
-    NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
-    expand_explanation_refs(Children,Facts,NewChildren),
+    %NewNode=..[Type,Output,Ref,Module,Source,NewOrigin,NewChildren],
+    %expand_explanation_refs(Children,Facts,NewChildren),
     expand_explanation_refs(Nodes,Facts,NewNodes).
 expand_explanation_refs([],_,[]). 
 

--- a/swish/explanation_renderer.pl
+++ b/swish/explanation_renderer.pl
@@ -24,15 +24,15 @@ term_rendering(Explanation, _Vars, _Options) -->
 
 % explanationHTML(ExpandedExplanationTree,TermerizedHTMLlist)
 % works ok but not inside SWISH because of its style clobbering ways:
-explanationHTML(s(G,Ref,_,_,_,C),[li(title="Rule inference step",["~w"-[NG],Navigator]),ul(CH)]) :- 
+explanationHTML(s(G,Ref,_,_,_,C),[li(title="Rule inference step",["It is the case that: ~w , as proved by"-[NG],Navigator]), Because, ul(CH)]) :- 
     niceModule(G,NG),
-    clauseNavigator(Ref,Navigator), explanationHTML(C,CH).
+    clauseNavigator(Ref,Navigator), explanationHTML(C,CH), (CH\=[] -> Because = 'because'; Because=''). 
 explanationHTML(u(G,Ref,_,_,_,[]),[li(title="Unknown",["~w ?"-[NG],Navigator])]) :-
     niceModule(G,NG),
     clauseNavigator(Ref,Navigator).
 %explanationHTML(unknown(at(G,K)),[li([style="color:blue",title="Unknown"],a(href=K,"~w"-[G]))]).
 % explanationHTML(unknown(at(G,K)),[li([p("UNKNOWN: ~w"-[G]),p(i(K))])]).
-explanationHTML(f(G,Ref,_,_,_,C),[li(title="Failed goal",[span(style="color:red","~w ~~"-[NG]),Navigator]), ul(CH)]) :- 
+explanationHTML(f(G,Ref,_,_,_,C),[li(title="Failed goal",[span(style="color:red","It is NOT the case that: ~w ~~"-[NG]),Navigator]), ul(CH)]) :- 
     niceModule(G,NG),
     clauseNavigator(Ref,Navigator), explanationHTML(C,CH).
 %explanationHTML(at(G,K),[li(style="color:green",a(href=K,"~w"-[G]))]).

--- a/swish/user_module_for_swish.pl
+++ b/swish/user_module_for_swish.pl
@@ -95,7 +95,7 @@ clauseNavigator(C,H) :- clauseNavigator_(C,H,_).
 clauseNavigator(C,H,AP) :- clauseNavigator_(C,H,AP).
 
 % returns an element, as well as an anchor property
-clauseNavigator_(Ref,span([a([onclick=Handler]," TaxLog")|Origin]), onclick=Handler) :- 
+clauseNavigator_(Ref,span([a([onclick=Handler]," Target ")|Origin]), onclick=Handler) :- 
     blob(Ref,clause), clause_property(Ref,file(F_)), clause_property(Ref,line_count(L)),
     myClause2(_H,_Time,Module_,_Body,Ref,_IsProlog,_URL,_E), 
     !,

--- a/swish/user_module_for_swish.pl
+++ b/swish/user_module_for_swish.pl
@@ -95,22 +95,31 @@ clauseNavigator(C,H) :- clauseNavigator_(C,H,_).
 clauseNavigator(C,H,AP) :- clauseNavigator_(C,H,AP).
 
 % returns an element, as well as an anchor property
-clauseNavigator_(Ref,span([a([onclick=Handler]," Target ")|Origin]), onclick=Handler) :- 
-    blob(Ref,clause), clause_property(Ref,file(F_)), clause_property(Ref,line_count(L)),
-    myClause2(_H,_Time,Module_,_Body,Ref,_IsProlog,_URL,_E), 
+clauseNavigator_(Ref,span([a([onclick=Handler]," KB ")|Origin]), onclick=Handler) :- 
+    blob(Ref,clause), clause_property(Ref,file(F_)), clause_property(Ref,line_count(_PrologLine)),
+    myClause2(_H,_,Module_,_Body,Ref,_IsProlog,_URL,_E, LE_Line), 
     !,
+	%(le_input:parsed*-> Line=LE_Line;Line=PrologLine), % origin in LE or in Taxlog?
     % Module_ will be the temporary SWISH module with the current window's program
     % This seems to break links to source: (shouldMapModule(Module,Module_)-> kp_location(Module,F,true) ;(
     (moduleMapping(Module,Module_)-> must_succeed(kp_location(Module,F,true),one) ;(
         % strip swish "file" header if present:
 		(sub_atom(F_,0,_,R,'swish://'), sub_atom(F_,_,R,0,F)) -> true ; F=F_
         )),
-    refToOrigin(Ref,URL),
+    refToOrigin(Ref,MName), moduleName2URL(MName, URL), 
     % could probably use https://www.swi-prolog.org/pldoc/doc_for?object=js_call//1 , but having trouble embedding that as attribute above:
-    format(string(Handler),"myPlayFile('~a',~w);",[F,L]),
+    format(string(Handler),"myPlayFile('~a',~w);",[F,LE_Line]), % format(string(Handler),"myPlayFile('~a',~w);",[F,L]),
     Origin = [a([href=URL, target='_self']," Text")].
-clauseNavigator_(Ref,i(" ~w"-[Ref]),onclick='').
+clauseNavigator_(Ref,i(" hypothesis (~w) in scenario"-[Ref]),onclick='').
 
+moduleName2URL(Name, URL) :-  split_module_name(Name, URL), !.
+moduleName2URL(URL, URL). 
+
+split_module_name(Name,URL):-
+	sub_atom(Name,U,1,_,'+'),
+	UU is U+1, 
+	sub_atom(Name,UU,_,0,URL), !. 
+	%print_message(informational, URL). 
 
 :- use_module(explanation_renderer,[]).
 :- use_rendering(explanation_renderer).

--- a/syntax.pl
+++ b/syntax.pl
@@ -82,6 +82,8 @@ taxlog2prolog(query(Name,Goal),delimiter-[classify,classify],query(Name,Goal)).
 
 % extending to cover new structural changes at semantical level
 
+semantics2prolog(if(N,H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
+    taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
 semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
 %semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-B)) :- !,

--- a/syntax.pl
+++ b/syntax.pl
@@ -33,7 +33,8 @@ limitations under the License.
     op(700,xfx,user:before),
     op(700,xfx,user:after),
     taxlog2prolog/3,
-    semantics2prolog/3
+    semantics2prolog/3,
+    current_source/1
     ]).
 
 :- use_module(kp_loader,[kp_location/3,my_xref_defined/3]).
@@ -81,8 +82,10 @@ taxlog2prolog(query(Name,Goal),delimiter-[classify,classify],query(Name,Goal)).
 
 % extending to cover new structural changes at semantical level
 
-semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-B)) :- !,
-    SpecH=classify, SpecB=classify. 
+semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
+    taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
+%semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-B)) :- !,
+%    SpecH=classify, SpecB=classify. 
     %taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
 %semantics2prolog(mainGoal(G,Description),delimiter-[Spec,classify],(mainGoal(G,Description):-(_=1->true;GG))) :- !, % hack to avoid 'unreferenced' highlight in SWISH
 %    functor(G,F,N), functor(GG,F,N), % avoid "Singleton-marked variable appears more than once"

--- a/syntax.pl
+++ b/syntax.pl
@@ -45,27 +45,27 @@ limitations under the License.
 
 /*
 Transforms source rules into our "no time on heads" representation, using a body wrapper to carry extra information:
-    taxlogBody(RealBody,HasTimeOnHead,Time,URL,Why)
+    targetBody(RealBody,HasTimeOnHead,Time,URL,Why,LE_line)
 
-P on T if Body  -->  P :- taxlogBody(Body,true,T,'',[])
-P on T because Why :- PrologBody   -->   P :- taxlogBody(PrologBody,true,T,'',Why)
-P if Body  --> P  :- taxlogBody(Body,false,_,'',[])
+P on T if Body  -->  P :- targetBody(Body,true,T,'',[],LE_line)
+P on T because Why :- PrologBody   -->   P :- targetBody(PrologBody,true,T,'',Why,LE_line)
+P if Body  --> P  :- targetBody(Body,false,_,'',[],LE_line)
 Admissible variants with a specific URL:
-P on T at URL if Body --> P :- taxlogBody(Body,true,T,URL,[])
-P at URL if Body  -->  P :- taxlogBody(Body,false,_,URL,[])
+P on T at URL if Body --> P :- targetBody(Body,true,T,URL,[],LE_line)
+P at URL if Body  -->  P :- targetBody(Body,false,_,URL,[],LE_line)
 */
 
 taxlog2prolog(if(function(Call,Result),Body), neck(if)-[delimiter-[head(meta,Call),classify],SpecB], (function(Call,Result):-Body)) :- !,
     taxlogBodySpec(Body,SpecB).
-taxlog2prolog(if(at(on(H,T),Url),B), neck(if)-[delimiter-[delimiter-[SpecH,classify],classify],SpecB], (H:-taxlogBody(B,true,T,Url,[]))) :- !,
+taxlog2prolog(if(at(on(H,T),Url),B), neck(if)-[delimiter-[delimiter-[SpecH,classify],classify],SpecB], (H:-targetBody(B,true,T,Url,[],_))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
-taxlog2prolog(if(at(H,Url),B), neck(if)-[delimiter-[SpecH,classify],SpecB], (H:-taxlogBody(B,false,_T,Url,[]))) :- !,
+taxlog2prolog(if(at(H,Url),B), neck(if)-[delimiter-[SpecH,classify],SpecB], (H:-targetBody(B,false,_T,Url,[],_))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
-taxlog2prolog(if(on(H,T),B), neck(if)-[delimiter-[SpecH,classify],SpecB], (H:-taxlogBody(B,true,T,'',[]))) :- !,
+taxlog2prolog(if(on(H,T),B), neck(if)-[delimiter-[SpecH,classify],SpecB], (H:-targetBody(B,true,T,'',[],_))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
-taxlog2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
+taxlog2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-targetBody(B,false,_,'',[],_))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
-taxlog2prolog((because(on(H,T),Why):-B), neck(clause)-[ delimiter-[delimiter-[SpecH,classify],classify], SpecB ], (H:-taxlogBody(call(B),true,T,'',Why))) :- Why\==[], !,
+taxlog2prolog((because(on(H,T),Why):-B), neck(clause)-[ delimiter-[delimiter-[SpecH,classify],classify], SpecB ], (H:-targetBody(call(B),true,T,'',Why,_))) :- Why\==[], !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
 taxlog2prolog(mainGoal(G,Description),delimiter-[Spec,classify],(mainGoal(G,Description):-(_=1->true;GG))) :- !, % hack to avoid 'unreferenced' highlight in SWISH
     functor(G,F,N), functor(GG,F,N), % avoid "Singleton-marked variable appears more than once"
@@ -82,9 +82,10 @@ taxlog2prolog(query(Name,Goal),delimiter-[classify,classify],query(Name,Goal)).
 
 % extending to cover new structural changes at semantical level
 
-semantics2prolog(if(N,H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
+semantics2prolog(if(N,H,B),neck(if)-[SpecH,SpecB],(H:-targetBody(B,false,_,'',[],NN))) :- !, % for testing N
+    NN is N + 3, % correction to linecount
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
-semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-taxlogBody(B,false,_,'',[]))) :- !,
+semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-targetBody(B,false,_,'',[],0))) :- !,
     taxlogHeadSpec(H,SpecH), taxlogBodySpec(B,SpecB).
 %semantics2prolog(if(H,B),neck(if)-[SpecH,SpecB],(H:-B)) :- !,
 %    SpecH=classify, SpecB=classify. 


### PR DESCRIPTION
taxlogBody/5 wrapper has been transformed (into targetBody/6) to store the line in the LE document of the rule that is being translated into prolog. The renderer has been modified to highlight that line when the link is clicked on in the explanation tree. 