### PR TITLE
Add predicate to return a list with the explanation

### DIFF
--- a/kb/cittadinanza_ita.le
+++ b/kb/cittadinanza_ita.le
@@ -1,6 +1,4 @@
-:- module('cittadinanza_italiana+http://tests.com',[]).
-
-en("il linguaggio destinazione è: prolog.
+il linguaggio destinazione è: prolog.
 
 i modelli sono:
 *una persona* ha la cittadinanza italiana,
@@ -46,10 +44,3 @@ filippo è nato in italia.
 
 domanda uno è:
 quale persona ha la cittadinanza italiana.
-
-").
-
-/** <examples>
-?- answer("query uno with scenario giuseppe").
-?- answer("query uno with scenario filippo").
-*/


### PR DESCRIPTION
This adds a predicate to evaluate the result and explanation, returning a nested list with the result instead of the html representation.

Currently the list is used to parse and show the output in the vscode extension (currently available at https://github.com/LyzardKing/LogicalEnglishExtension).