### PR TITLE
Fix show prolog

### DIFF
--- a/le_answer.pl
+++ b/le_answer.pl
@@ -558,12 +558,12 @@ show(prolog) :-
     show(scenarios). 
 
 show(rules) :- %trace, 
-    this_capsule(SwishModule), 
+    psem(File),
     findall(Pr, le_input:filtered_dictionary(Pr), Preds), 
     remove_duplicates(Preds, PredsClean), 
     %print_message(informational, "Swish Module ~w"-[SwishModule]), 
     findall((Pred :- Body), 
-        ( member(Pred, PredsClean), clause(SwishModule:Pred, Body_), unwrapBody(Body_, Body)), Predicates),
+        ( member(Pred, PredsClean), clause(File:Pred, Body_), unwrapBody(Body_, Body)), Predicates),
     %print_message(informational, "Rules  ~w"-[Predicates]),
     %forall(member(Clause, [(is_(A,B) :- (nonvar(B), is(A,B)))|Predicates]), portray_clause_ind(Clause)).
     forall(member(Clause, Predicates), portray_clause_ind(Clause)).
@@ -577,23 +577,23 @@ show(rules) :- %trace,
 %), 
 
 show(metarules) :- %trace, 
-    this_capsule(SwishModule), 
+    psem(File),
     findall((Pred :- Body), 
         (meta_dict(PredicateElements, _, _), PredicateElements\=[], 
-         Pred=..PredicateElements, clause(SwishModule:Pred, Body_), unwrapBody(Body_, Body)), Predicates),
+         Pred=..PredicateElements, clause(File:Pred, Body_), unwrapBody(Body_, Body)), Predicates),
     forall(member(Clause, Predicates), portray_clause_ind(Clause)).
 
 show(queries) :- %trace, 
-    this_capsule(SwishModule), 
+    psem(File),
     findall((query(A,B) :- true), 
-        (clause(SwishModule:query(A,B), _)), Predicates),
+        (clause(File:query(A,B), _)), Predicates),
     %print_message(informational, "Queries  ~w"-[Predicates]),
     forall(member(Clause, Predicates), portray_clause_ind(Clause)).
 
 show(scenarios) :- %trace, 
-    this_capsule(SwishModule), 
+    psem(File),
     findall((example(A,B) :- true), 
-        (clause(SwishModule:example(A,B), _)), Predicates),
+        (clause(File:example(A,B), _)), Predicates),
     forall(member(Clause, Predicates), portray_clause_ind(Clause)).
 
 show(templates) :-


### PR DESCRIPTION
Change this_capsule to psem

The show(...) rules still used the older version, so they were not presenting any output.
It still need the cleanup section to be removed, otherwise it has nothing asserted to show.

Maybe the cleanup should be left to a different rule that can be called depending on the usecase. In the extension UI, unless the code is changed I don't need to reload it, and keeping it loaded (without reasserting) might be better. 