### PR TITLE
Add explain_json operation and LE_API_TOKEN env-var support

### DIFF
--- a/api.md
+++ b/api.md
@@ -4,7 +4,17 @@ The LE API is a JSON-over-HTTP REST endpoint served at `/leapi` (default port 30
 
 ## Authentication
 
-Every request must include `"token": "myToken123"` in the JSON body.
+Every request must include a `"token"` field in the JSON body. The expected
+token is:
+
+- The value of the `LE_API_TOKEN` environment variable, if set when the server
+  started, OR
+- `"myToken123"` as the historical default fallback when `LE_API_TOKEN` is
+  unset.
+
+This behaviour is backwards-compatible: callers using the historical default
+continue to work unchanged, while deployments needing a real shared secret
+can set the env var without code changes.
 
 ## Request / Response format
 
@@ -115,6 +125,89 @@ Same fields as `answer`.
 
 ```json
 { "results": [ <explanation>, ... ] }
+```
+
+The `<explanation>` is rendered as an HTML string nested-list. For machine
+consumption of the proof-tree shape (preserving per-node `ref`, `source`,
+and `origin` annotations), use [`explain_json`](#explain_json--like-explain-but-with-a-structured-json-proof-tree)
+instead.
+
+---
+
+### `explain_json` — Like `explain` but with a structured JSON proof tree
+
+Identical to `explain` in inputs and applicability. The difference is in the
+response shape: each answer's `explanation` field is a list of structured node
+dicts rather than a stringified HTML rendering. This preserves the per-node
+`ref` (clause reference), `source` (originating program / module), and
+`origin` (the actual Prolog clause that fired) annotations that the HTML
+rendering strips out via the underscored variables in `explanationLEHTML/2`.
+
+Designed for agentic / programmatic consumers (e.g. compliance certifiers,
+structured-output advisory systems) that need to attach proof trees to
+structured output without having to parse rendered HTML.
+
+**Request**
+
+```json
+{
+  "token": "myToken123",
+  "operation": "explain_json",
+  "file": "<program_name>",
+  "document": "<LE source text>",
+  "theQuery": "<query sentence>",
+  "scenario": "<scenario name>"
+}
+```
+
+Same fields as `explain` / `answer`.
+
+**Response**
+
+```json
+{
+  "results": [
+    {
+      "answer": "Yes | No | Unknown | Failure",
+      "bindings": "<stringified ground goal>",
+      "explanation": [
+        {
+          "type": "proven | failed | unknown",
+          "literal": "<stringified goal>",
+          "ref": "<clause reference or null>",
+          "source": "<source program / module or null>",
+          "origin": "<the actual Prolog clause that fired or null>",
+          "children": [ <node>, ... ]
+        },
+        ...
+      ]
+    },
+    ...
+  ]
+}
+```
+
+Node `type` values:
+- `"proven"`   — the goal was successfully proved (SLD-resolution succeeded).
+- `"failed"`   — the goal could not be proved.
+- `"unknown"`  — the goal is a hypothesis lacking sufficient facts.
+
+For a leaf step that exercised a Prolog built-in (e.g. an arithmetic
+comparison `160000 is greater or equal to 150000`), `ref` and `origin` are
+`null` and `source` carries the LE program name. For a step that exercised
+a user-defined rule, all four annotation fields are populated.
+
+**curl example**
+
+```bash
+curl -s -X POST http://localhost:3050/leapi \
+  -H 'Content-Type: application/json' \
+  -d '{"token":"myToken123",
+       "operation":"explain_json",
+       "file":"gst",
+       "document":"<full LE source>",
+       "theQuery":"A",
+       "scenario":"A"}'
 ```
 
 ---

--- a/api.pl
+++ b/api.pl
@@ -98,7 +98,16 @@ handle_api(Request) :-
     http_read_json_dict(Request, Payload, [value_string_as(atom)]),
     %asserta(my_request(Request)), % for debugging
     %print_message(informational,"Request Payload: ~w"-[Payload]),
-    assertion(Payload.token=='myToken123'),
+    % LodgeiT/ClawDog 2026-05-13: honour LE_API_TOKEN env var when set,
+    % otherwise fall back to the historical default 'myToken123' for
+    % backwards compatibility. The assertion semantics are preserved
+    % (throws on mismatch) so no caller behaviour changes when the env
+    % var is unset.
+    (   getenv('LE_API_TOKEN', ExpectedToken_)
+    ->  atom_string(ExpectedToken, ExpectedToken_)
+    ;   ExpectedToken = 'myToken123'
+    ),
+    assertion(Payload.token == ExpectedToken),
     (entry_point(Payload,Result)->true;Result=_{error:"No answer"}),
     %print_message(informational,"returning Result: ~w"-[Result]),
     reply_json_dict(Result).
@@ -162,6 +171,31 @@ entry_point(R, _{results:AnswerExplanation}) :- get_dict(operation,R,explain), !
     % print_message(informational,"api.pl: Query ~w  Scenario ~w\n"-[R.theQuery, R.scenario]),
     le_answer:parse_and_query_all_answers(R.file, en(R.document), R.theQuery, with(R.scenario), AnswerExplanation). 
     %print_message(informational,"entry point explain returning: ~w"-[AnswerExplanation]).
+
+% Added by LodgeiT/ClawDog 2026-05-13: structured-JSON variant of `explain`.
+%
+% Mirrors the existing `explain` handler exactly, but routes the
+% LE_Explanation term through produce_json_explanation/2 instead of
+% produce_html_explanation/2. The returned `explanation` field is a list
+% of node dicts preserving the per-node Ref / Source / Origin annotations
+% that the HTML rendering strips.
+%
+% Motivation: downstream consumers of /leapi (e.g. agentic certifiers
+% integrating LE proof trees into structured advisory output) need a
+% machine-readable proof-tree for prolog-target programs without forcing
+% them to switch to taxlog or parse the rendered HTML. makeExplanationTree/2
+% already exposes the same shape for taxlog-target programs via the
+% `query` / `loadFactsAndQuery` ops; this brings parity for prolog-target.
+%
+% curl --header "Content-Type: application/json" --request POST \
+%   --data '{"token":"myToken123",
+%            "operation":"explain_json",
+%            "file":"gst",
+%            "document":"<full LE source>",
+%            "theQuery":"A",
+%            "scenario":"A"}' http://localhost:3050/leapi
+entry_point(R, _{results:AnswerExplanation}) :- get_dict(operation,R,explain_json), !,
+    le_answer:parse_and_query_all_answers_json(R.file, en(R.document), R.theQuery, with(R.scenario), AnswerExplanation).
 
 % NEW: Entry point for Gemini
 % curl --header "Content-Type: application/json" --request POST --data '{"token":"myToken123", "gemini_api_key": "..", "operation":"answer_via_llm", "file": "testllm", "document":" ... ", "userinput":"some input text"}' http://localhost:3050/leapi

--- a/le_answer.pl
+++ b/le_answer.pl
@@ -35,7 +35,8 @@ which can be used on the new command interface of LE on SWISH
     dump/4, dump/3, dump/2, dump_scasp/3, split_module_name/3, just_saved_scasp/2, psem/1, set_psem/1,
     prepare_query/6, assert_facts/2, retract_facts/2, parse_and_query/5, parse_and_query_and_explanation/6, parse_and_query_all_answers/5,
     parse_and_query_and_explanation_text/6, le_expanded_terms/2, show/1, source_lang/1, targetBody/6, query_and_explanation_text/4,
-    parse_and_load/5, parse_and_load/6, literal_to_sentence/3, literal_to_sentence/2, top2levels_predicate/3, top_intensional_predicate/3, retracting/2
+    parse_and_load/5, parse_and_load/6, literal_to_sentence/3, literal_to_sentence/2, top2levels_predicate/3, top_intensional_predicate/3, retracting/2,
+    produce_json_explanation/2, parse_and_query_all_answers_json/5
     ]).
 
 :- if(exists_source(library(pengines_sandbox))).
@@ -1445,6 +1446,153 @@ explanationLEText(f(G,_Ref,_,_,_,C),[Gs|RestTree]) :-
     with_output_to(string(Gs), format('"It is not the case that: ~w"', G)).
 explanationLEText([C1|Cn],CH) :- explanationLEText(C1,CH1), explanationLEText(Cn,CHn), append(CH1,CHn,CH).
 explanationLEText([],[]).
+
+% ============================================================================
+% JSON explanation producer (added by LodgeiT/ClawDog 2026-05-13)
+%
+% Walks the same le_Explanation(Trees) structure consumed by
+% produce_html_explanation/2 and produce_text_explanation/2, but emits a
+% JSON-dict-shaped representation that preserves the per-node Ref, Source,
+% and Origin fields. These fields are the load-bearing statutory-anchor
+% surface that the HTML rendering strips out (see explanationLEHTML/2 above
+% — the head pattern destructures `s(G,_Ref,_,_,_,C)` with underscores for
+% Ref/Source/Origin, making them unrecoverable from the rendered HTML).
+%
+% Output is a list of node dicts of the form:
+%   _{type: "proven"|"failed"|"unknown",
+%     literal: <stringified-goal>,
+%     ref:     <stringified-rule-ref or null>,
+%     source:  <stringified-source-annotation or null>,
+%     origin:  <stringified-text-origin or null>,
+%     children: [<dict>, ...]}
+%
+% Sibling to:
+%   produce_html_explanation/2  — HTML rendering (loses Ref/Source/Origin)
+%   produce_text_explanation/2  — plain-text rendering (also loses them)
+%   makeExplanationTree/2 in api.pl — a similar JSON shape exists but is
+%     gated behind the taxlog target language via query/loadFactsAndQuery
+%     ops. This predicate exposes the same structural information to the
+%     prolog target language via parse_and_query_all_answers_json/5 and
+%     the entry_point(explain_json) handler in api.pl.
+% ============================================================================
+
+produce_json_explanation(le_Explanation(Trees), JSON) :-
+    explanationLEJSON(Trees, JSON).
+
+% Successful proof step.
+explanationLEJSON(s(G, Ref, Source, Origin, _, C),
+                  [_{type: "proven",
+                     literal: Gs,
+                     ref: RefS,
+                     source: SrcS,
+                     origin: OrgS,
+                     children: CH}]) :-
+    term_string(G, Gs),
+    optional_string(Ref, RefS),
+    optional_string(Source, SrcS),
+    optional_string(Origin, OrgS),
+    explanationLEJSON(C, CH).
+
+% Unknown / unprovable hypothesis.
+explanationLEJSON(u(G, Ref, Source, Origin, _, []),
+                  [_{type: "unknown",
+                     literal: Gs,
+                     ref: RefS,
+                     source: SrcS,
+                     origin: OrgS,
+                     children: []}]) :-
+    term_string(G, Gs),
+    optional_string(Ref, RefS),
+    optional_string(Source, SrcS),
+    optional_string(Origin, OrgS).
+
+% Failed proof step.
+explanationLEJSON(f(G, Ref, Source, Origin, _, C),
+                  [_{type: "failed",
+                     literal: Gs,
+                     ref: RefS,
+                     source: SrcS,
+                     origin: OrgS,
+                     children: CH}]) :-
+    term_string(G, Gs),
+    optional_string(Ref, RefS),
+    optional_string(Source, SrcS),
+    optional_string(Origin, OrgS),
+    explanationLEJSON(C, CH).
+
+% List-recursion: walk siblings, concatenate dict lists.
+explanationLEJSON([C1|Cn], CH) :-
+    explanationLEJSON(C1, CH1),
+    explanationLEJSON(Cn, CHn),
+    append(CH1, CHn, CH).
+explanationLEJSON([], []).
+
+% Stringify a Ref/Source/Origin term, or emit null when unbound/empty.
+% Mirrors the conservative approach already used elsewhere in the file:
+% Ref, Source, Origin are recorded by the reasoner per-rule and may be
+% atoms, strings, variables, or empty atoms; coerce uniformly to
+% nullable-string for JSON safety.
+optional_string(T, null) :- var(T), !.
+optional_string('', null) :- !.
+optional_string("", null) :- !.
+optional_string([], null) :- !.
+optional_string(T, S) :-
+    (   string(T) -> S = T
+    ;   atom(T)   -> atom_string(T, S)
+    ;   term_string(T, S)
+    ).
+
+% Parallel to parse_and_query_all_answers/5, but bundles the structured JSON
+% explanation into each Answer dict instead of letting answer_all/3 stringify
+% it as HTML internally. Keeps the existing predicate untouched so all
+% downstream callers of parse_and_query_all_answers/5 continue to behave
+% identically.
+parse_and_query_all_answers_json(File, Document, Question, Scenario, JSONAnswers) :-
+    parse_and_load(File, Document, _, ExpandedTerms, _),
+    answer_all_json(Question, Scenario, JSONAnswers), !,
+    retracting(File, ExpandedTerms).
+
+% Parallel to answer_all/3 but emits structured JSON in the `explanation` field.
+answer_all_json(English, Arg, Results) :-
+    once( pre_answer(English, Arg, FactsPre, Module, InnerGoal) ),
+    append(FactsPre, [(is_a(A, B):-(is_a(A, C),is_a(C, B)))], Facts),
+    MAX_SECONDS = 0.4,
+    setup_call_catcher_cleanup(
+        assert_facts(Module, Facts),
+        catch_with_backtrace(
+            call_with_time_limit(MAX_SECONDS,
+                findall(Answer,
+                    ( reasoner:query(at(InnerGoal, Module), _U, le(LE_Explanation), Result),
+                      produce_json_explanation(LE_Explanation, JSON),
+                      correct_answer_json(InnerGoal, JSON, Result, Answer_),
+                      numbervars(InnerGoal),
+                      term_string(InnerGoal, Bindings, [numbervars(true)]),
+                      put_dict(bindings, Answer_, Bindings, Answer)
+                    ),
+                    Results)),
+            Error,
+            ( print_message(error, Error) )
+        ),
+        _Result,
+        retract_facts(Module, Facts)),
+    Results \== [],
+    !.
+answer_all_json(English, Arg, [ _{answer: "Failure",
+                                  explanation: [_{type: "failed",
+                                                  literal: FailureMsg,
+                                                  ref: null, source: null, origin: null,
+                                                  children: []}],
+                                  bindings: ""} ]) :-
+    with_output_to(string(FailureMsg),
+        format("Failed to answer question: ~w : ~w. Check your query/scenario, please.",
+               [English, Arg])), !.
+
+% Parallel to correct_answer/4 (used by answer_all/3) but produces JSON-shaped
+% answer dicts. correct_answer/4 is defined in reasoner.pl; we mirror only the
+% three result branches we actually receive (true / false / unknown).
+correct_answer_json(_InnerGoal, JSON, true,    _{answer: "Yes",     explanation: JSON}).
+correct_answer_json(_InnerGoal, JSON, false,   _{answer: "No",      explanation: JSON}).
+correct_answer_json(_InnerGoal, JSON, unknown, _{answer: "Unknown", explanation: JSON}).
 
 % Moved here so it loads in the wasm version, that doesn't have access to api.pl
 :- if(current_module(wasm)).


### PR DESCRIPTION
Two backwards-compatible additions to /leapi:

1. New 'explain_json' operation in api.pl, paralleling 'explain' but returning the proof tree as a list of structured JSON node dicts instead of a rendered HTML string. Each node carries: - type: 'proven' | 'failed' | 'unknown' - literal: stringified goal - ref: clause reference (null for built-ins) - source: originating program / module - origin: the actual Prolog clause that fired (null for built-ins) - children: recursive list This preserves the per-node Ref / Source / Origin annotations that the existing explanationLEHTML/2 rendering strips via underscored variables. Implemented as parse_and_query_all_answers_json/5 + answer_all_json/3 + produce_json_explanation/2 + explanationLEJSON/2 in le_answer.pl, sibling to the existing _html and _text emitters.

2. api.pl now honours an LE_API_TOKEN environment variable for the request-token check. When LE_API_TOKEN is set at server start, that value is the expected token; when unset, the historical default 'myToken123' continues to apply. Backwards-compatible: existing callers see no change unless the operator sets the env var.

Why explain_json: makeExplanationTree/2 already exposes the same structural information for taxlog-target programs via 'query' / 'loadFactsAndQuery'. This brings parity for prolog-target programs (declared via 'the target language is: prolog.'), unblocking agentic consumers that need machine-readable proof-trees without switching target languages or scraping HTML.

Tested against moreExamples/gst.le with the prolog target:
- The new explain_json op returns a 3-level proof tree for the Cherrio Charity scenario, with origin/source/ref populated on every rule-firing node and null on the arithmetic-comparison built-in.
- The existing 'explain' op continues to return identical HTML output (12/12 tests under moreExamples/gst.le.tests still ALL GOOD).

Authored by ClawDog (an autonomous compliance agent operating under LodgeiT Labs, https://github.com/lodgeit-labs) and architected / reviewed by Andrew Noble. The motivating use case is a deterministic proof-tree firewall layered on top of probabilistic RAG output — LE is the deterministic anchor, the agent fuses the LE proof tree with statutory provenance from a content-addressable knowledge graph at output time. Sharing the patch upstream because the JSON serialiser is a missing parity piece that benefits any agentic LE consumer, not just our specific stack.